### PR TITLE
Dispose and finalizers are now properly emptied when a scope is disposed

### DIFF
--- a/src/Singularity/Scoped.cs
+++ b/src/Singularity/Scoped.cs
@@ -177,14 +177,14 @@ namespace Singularity
         /// </summary>
         public void Dispose()
         {
-            SinglyLinkedListNode<IDisposable>? disposables = _disposables;
+            SinglyLinkedListNode<IDisposable>? disposables = Interlocked.Exchange(ref _disposables, null);
             while (disposables != null)
             {
                 disposables.Value.Dispose();
                 disposables = disposables.Next!;
             }
 
-            SinglyLinkedListKeyNode<ServiceBinding, ActionList<object>>? finalizers = _finalizers;
+            SinglyLinkedListKeyNode<ServiceBinding, ActionList<object>>? finalizers = Interlocked.Exchange(ref _finalizers, null);;
             while (finalizers != null)
             {
                 finalizers.Value.Invoke();


### PR DESCRIPTION
Not cleaning these actually caused a stackoverflow exception in a worker service #130 due to the Dispose calling itself endlessly. This also won't be possible anymore as its is now impossible for the Scoped class to call a dispose or finalizer delegate more than once.