### PR TITLE
Removed As method and replaced it with a different api with more safety

### DIFF
--- a/src/Singularity.Microsoft.DependencyInjection/ConfigurationExtensions.cs
+++ b/src/Singularity.Microsoft.DependencyInjection/ConfigurationExtensions.cs
@@ -59,31 +59,42 @@ namespace Singularity
             }
             else if (registration.ImplementationInstance != null)
             {
-                config.Register(registration.ServiceType, c => c.Inject(Expression.Constant(registration.ImplementationInstance)), ConstructorResolvers.BestMatch);
+                config.Register(registration.ServiceType, c =>
+                {
+                    c.Inject(Expression.Constant(registration.ImplementationInstance))
+                     .With(ConstructorResolvers.BestMatch);
+                });
             }
             else
             {
-                config.Register(registration.ServiceType, registration.ImplementationType, c => c.With(ConvertLifetime(registration.Lifetime)), ConstructorResolvers.BestMatch);
+                config.Register(registration.ServiceType, registration.ImplementationType, c =>
+                {
+                    c.With(ConvertLifetime(registration.Lifetime))
+                     .With(ConstructorResolvers.BestMatch);
+                });
             }
         }
 
         private static void RegisterWithFactory(ContainerBuilder config, ServiceDescriptor registration)
         {
             ParameterExpression serviceProviderParameter = Expression.Parameter(typeof(IServiceProvider));
-            config.Register(registration.ServiceType, c => c.Inject(
-                    Expression.Lambda(
-                        Expression.Convert(
-                            Expression.Invoke(
-                                Expression.Constant(registration.ImplementationFactory), serviceProviderParameter),
-                            registration.ServiceType), serviceProviderParameter))
-                .With(ConvertLifetime(registration.Lifetime)), ConstructorResolvers.BestMatch);
+            config.Register(registration.ServiceType, c =>
+            {
+                c.Inject(Expression.Lambda(
+                             Expression.Convert(
+                                 Expression.Invoke(
+                                     Expression.Constant(registration.ImplementationFactory), serviceProviderParameter),
+                                 registration.ServiceType), serviceProviderParameter))
+                 .With(ConvertLifetime(registration.Lifetime))
+                 .With(ConstructorResolvers.BestMatch);
+            });
         }
 
         private static ILifetime ConvertLifetime(ServiceLifetime serviceLifetime)
         {
             return serviceLifetime switch
             {
-                ServiceLifetime.Singleton => (ILifetime) Lifetimes.PerContainer,
+                ServiceLifetime.Singleton => Lifetimes.PerContainer,
                 ServiceLifetime.Scoped => Lifetimes.PerScope,
                 ServiceLifetime.Transient => Lifetimes.Transient,
                 _ => throw new ArgumentOutOfRangeException(nameof(serviceLifetime), serviceLifetime, null)

--- a/src/Singularity/Collections/RegistrationStore.cs
+++ b/src/Singularity/Collections/RegistrationStore.cs
@@ -12,12 +12,12 @@ namespace Singularity.Collections
 
         internal IModule? CurrentModule;
 
-        public void AddDecorator(Type dependencyType, Expression expression)
+        public void AddDecorator(Type serviceType, Expression expression)
         {
-            if (!Decorators.TryGetValue(dependencyType, out ArrayList<Expression> list))
+            if (!Decorators.TryGetValue(serviceType, out ArrayList<Expression> list))
             {
                 list = new ArrayList<Expression>();
-                Decorators.Add(dependencyType, list);
+                Decorators.Add(serviceType, list);
             }
             list.Add(expression);
         }

--- a/src/Singularity/Collections/SinglyLinkedListNode.cs
+++ b/src/Singularity/Collections/SinglyLinkedListNode.cs
@@ -128,6 +128,25 @@ namespace Singularity.Collections
         }
 
         /// <summary>
+        /// returns a new <see cref="SinglyLinkedListNode{T}"/> that points to the passed <paramref name="previous"/> node.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="previous"></param>
+        /// <param name="collection"></param>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [return: NotNullIfNotNull("previous")]
+        public static SinglyLinkedListNode<T>? Add<T>(this SinglyLinkedListNode<T>? previous, IEnumerable<T> collection)
+        {
+            foreach (var element in collection)
+            {
+                previous = new SinglyLinkedListNode<T>(previous, element);
+            }
+
+            return previous;
+        }
+
+        /// <summary>
         /// Converts the passed <paramref name="collection"/> to a <see cref="SinglyLinkedListNode{T}"/>
         /// Note: reverses the order of the elements.
         /// </summary>

--- a/src/Singularity/Container.cs
+++ b/src/Singularity/Container.cs
@@ -234,7 +234,7 @@ namespace Singularity
         /// </summary>
 		public void Dispose()
         {
-            ContainerScope?.Dispose();
+            ContainerScope.Dispose();
             IsDisposed = true;
         }
 

--- a/src/Singularity/ContainerBuilder.cs
+++ b/src/Singularity/ContainerBuilder.cs
@@ -46,7 +46,7 @@ namespace Singularity
         }
 
         /// <summary>
-        /// Registers a new strongly typed binding.
+        /// Registers a new service using the strongly typed API. The service can be resolved using <typeparamref name="TImplementation"/>
         /// </summary>
         /// <typeparam name="TImplementation"></typeparam>
         /// <param name="configurator"></param>
@@ -61,7 +61,7 @@ namespace Singularity
         }
 
         /// <summary>
-        /// Registers a new strongly typed binding.
+        /// Registers a new service using the strongly typed API. The service can be resolved using <typeparamref name="TImplementation"/> or <typeparamref name="TService1"/>
         /// </summary>
         /// <typeparam name="TService1"></typeparam>
         /// <typeparam name="TImplementation"></typeparam>
@@ -79,7 +79,7 @@ namespace Singularity
         }
 
         /// <summary>
-        /// Registers a new strongly typed binding.
+        /// Registers a new service using the strongly typed API. The service can be resolved using <typeparamref name="TImplementation"/>, <typeparamref name="TService1"/> or <typeparamref name="TService2"/>
         /// </summary>
         /// <typeparam name="TService1"></typeparam>
         /// <typeparam name="TService2"></typeparam>
@@ -100,7 +100,7 @@ namespace Singularity
         }
 
         /// <summary>
-        /// Registers a new strongly typed binding.
+        /// Registers a new service using the strongly typed API. The service can be resolved using <typeparamref name="TImplementation"/>, <typeparamref name="TService1"/>, <typeparamref name="TService2"/> or <typeparamref name="TService3"/>
         /// </summary>
         /// <typeparam name="TService1"></typeparam>
         /// <typeparam name="TService2"></typeparam>
@@ -120,6 +120,33 @@ namespace Singularity
                                 .Add(typeof(TService1))
                                 .Add(typeof(TService2))
                                 .Add(typeof(TService3));
+            RegisterInternal(configurator, serviceTypes, callerFilePath, callerLineNumber);
+        }
+
+        /// <summary>
+        /// Registers a new service using the strongly typed API. The service can be resolved using <typeparamref name="TImplementation"/>, <typeparamref name="TService1"/>, <typeparamref name="TService2"/>, <typeparamref name="TService3"/> or <typeparamref name="TService4"/>
+        /// </summary>
+        /// <typeparam name="TService1"></typeparam>
+        /// <typeparam name="TService2"></typeparam>
+        /// <typeparam name="TService3"></typeparam>
+        /// <typeparam name="TService4"></typeparam>
+        /// <typeparam name="TImplementation"></typeparam>
+        /// <param name="configurator"></param>
+        /// <param name="callerFilePath"></param>
+        /// <param name="callerLineNumber"></param>
+        public void Register<TService1, TService2, TService3, TService4, TImplementation>(Action<StronglyTypedServiceConfigurator<TImplementation>>? configurator = null, [CallerFilePath]string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+            where TImplementation : class, TService1, TService2, TService3, TService4
+        {
+            ServiceTypeValidator.Cache<TImplementation>.CheckIsEnumerable();
+            ServiceTypeValidator.Cache<TService1>.CheckIsEnumerable();
+            ServiceTypeValidator.Cache<TService2>.CheckIsEnumerable();
+            ServiceTypeValidator.Cache<TService3>.CheckIsEnumerable();
+            ServiceTypeValidator.Cache<TService4>.CheckIsEnumerable();
+            var serviceTypes = SinglyLinkedListNodeTypeCache<TImplementation>.Instance
+                                .Add(typeof(TService1))
+                                .Add(typeof(TService2))
+                                .Add(typeof(TService3))
+                                .Add(typeof(TService4));
             RegisterInternal(configurator, serviceTypes, callerFilePath, callerLineNumber);
         }
 

--- a/src/Singularity/ContainerBuilder.cs
+++ b/src/Singularity/ContainerBuilder.cs
@@ -9,7 +9,7 @@ using Singularity.Expressions;
 namespace Singularity
 {
     /// <summary>
-    /// A class to make configuring dependencies easier
+    /// A class to make configuring services easier
     /// </summary>
     public sealed class ContainerBuilder
     {
@@ -48,122 +48,185 @@ namespace Singularity
         /// <summary>
         /// Registers a new strongly typed binding.
         /// </summary>
-        /// <typeparam name="TInstance"></typeparam>
+        /// <typeparam name="TImplementation"></typeparam>
         /// <param name="configurator"></param>
-        /// <param name="constructorSelector"></param>
         /// <param name="callerFilePath"></param>
         /// <param name="callerLineNumber"></param>
-        public void Register<TInstance>(Action<StronglyTypedServiceConfigurator<TInstance, TInstance>>? configurator = null, IConstructorResolver? constructorSelector = null, [CallerFilePath]string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
-            where TInstance : class
+        public void Register<TImplementation>(Action<StronglyTypedServiceConfigurator<TImplementation>>? configurator = null, [CallerFilePath]string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+            where TImplementation : class
         {
-            RegisterInternal(configurator, constructorSelector, callerFilePath, callerLineNumber);
+            ServiceTypeValidator.Cache<TImplementation>.CheckIsEnumerable();
+            var serviceTypes = SinglyLinkedListNodeTypeCache<TImplementation>.Instance;
+            RegisterInternal(configurator, serviceTypes, callerFilePath, callerLineNumber);
         }
 
         /// <summary>
         /// Registers a new strongly typed binding.
         /// </summary>
-        /// <typeparam name="TDependency"></typeparam>
-        /// <typeparam name="TInstance"></typeparam>
+        /// <typeparam name="TService1"></typeparam>
+        /// <typeparam name="TImplementation"></typeparam>
         /// <param name="configurator"></param>
-        /// <param name="constructorSelector"></param>
         /// <param name="callerFilePath"></param>
         /// <param name="callerLineNumber"></param>
-        public void Register<TDependency, TInstance>(Action<StronglyTypedServiceConfigurator<TDependency, TInstance>>? configurator = null, IConstructorResolver? constructorSelector = null, [CallerFilePath]string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
-            where TInstance : class, TDependency
+        public void Register<TService1, TImplementation>(Action<StronglyTypedServiceConfigurator<TImplementation>>? configurator = null, [CallerFilePath]string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+            where TImplementation : class, TService1
         {
-            RegisterInternal(configurator, constructorSelector, callerFilePath, callerLineNumber);
+            ServiceTypeValidator.Cache<TImplementation>.CheckIsEnumerable();
+            ServiceTypeValidator.Cache<TService1>.CheckIsEnumerable();
+            var serviceTypes = SinglyLinkedListNodeTypeCache<TImplementation>.Instance
+                                  .Add(typeof(TService1));
+            RegisterInternal(configurator, serviceTypes, callerFilePath, callerLineNumber);
+        }
+
+        /// <summary>
+        /// Registers a new strongly typed binding.
+        /// </summary>
+        /// <typeparam name="TService1"></typeparam>
+        /// <typeparam name="TService2"></typeparam>
+        /// <typeparam name="TImplementation"></typeparam>
+        /// <param name="configurator"></param>
+        /// <param name="callerFilePath"></param>
+        /// <param name="callerLineNumber"></param>
+        public void Register<TService1, TService2, TImplementation>(Action<StronglyTypedServiceConfigurator<TImplementation>>? configurator = null, [CallerFilePath]string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+            where TImplementation : class, TService1, TService2
+        {
+            ServiceTypeValidator.Cache<TImplementation>.CheckIsEnumerable();
+            ServiceTypeValidator.Cache<TService1>.CheckIsEnumerable();
+            ServiceTypeValidator.Cache<TService2>.CheckIsEnumerable();
+            var serviceTypes = SinglyLinkedListNodeTypeCache<TImplementation>.Instance
+                                  .Add(typeof(TService1))
+                                  .Add(typeof(TService2));
+            RegisterInternal(configurator, serviceTypes, callerFilePath, callerLineNumber);
+        }
+
+        /// <summary>
+        /// Registers a new strongly typed binding.
+        /// </summary>
+        /// <typeparam name="TService1"></typeparam>
+        /// <typeparam name="TService2"></typeparam>
+        /// <typeparam name="TService3"></typeparam>
+        /// <typeparam name="TImplementation"></typeparam>
+        /// <param name="configurator"></param>
+        /// <param name="callerFilePath"></param>
+        /// <param name="callerLineNumber"></param>
+        public void Register<TService1, TService2, TService3, TImplementation>(Action<StronglyTypedServiceConfigurator<TImplementation>>? configurator = null, [CallerFilePath]string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+            where TImplementation : class, TService1, TService2, TService3
+        {
+            ServiceTypeValidator.Cache<TImplementation>.CheckIsEnumerable();
+            ServiceTypeValidator.Cache<TService1>.CheckIsEnumerable();
+            ServiceTypeValidator.Cache<TService2>.CheckIsEnumerable();
+            ServiceTypeValidator.Cache<TService3>.CheckIsEnumerable();
+            var serviceTypes = SinglyLinkedListNodeTypeCache<TImplementation>.Instance
+                                .Add(typeof(TService1))
+                                .Add(typeof(TService2))
+                                .Add(typeof(TService3));
+            RegisterInternal(configurator, serviceTypes, callerFilePath, callerLineNumber);
         }
 
         /// <summary>
         /// Registers a new weakly typed binding.
         /// </summary>
-        /// <param name="instanceType"></param>
+        /// <param name="implementationType"></param>
         /// <param name="configurator"></param>
-        /// <param name="constructorSelector"></param>
         /// <param name="callerFilePath"></param>
         /// <param name="callerLineNumber"></param>
-        public void Register(Type instanceType, Action<WeaklyTypedServiceConfigurator>? configurator = null, IConstructorResolver? constructorSelector = null, [CallerFilePath]string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+        public void Register(Type implementationType, Action<WeaklyTypedServiceConfigurator>? configurator = null, [CallerFilePath]string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
         {
-            RegisterInternal(instanceType, instanceType, configurator, constructorSelector, callerFilePath, callerLineNumber);
+            RegisterInternal(new SinglyLinkedListNode<Type>(implementationType), implementationType, configurator, callerFilePath, callerLineNumber);
         }
 
         /// <summary>
         /// Registers a new weakly typed binding.
         /// </summary>
-        /// <param name="dependencyType"></param>
-        /// <param name="instanceType"></param>
+        /// <param name="serviceType"></param>
+        /// <param name="implementationType"></param>
         /// <param name="configurator"></param>
-        /// <param name="constructorSelector"></param>
         /// <param name="callerFilePath"></param>
         /// <param name="callerLineNumber"></param>
-        public void Register(Type dependencyType, Type instanceType, Action<WeaklyTypedServiceConfigurator>? configurator = null, IConstructorResolver? constructorSelector = null, [CallerFilePath]string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+        public void Register(Type serviceType, Type implementationType, Action<WeaklyTypedServiceConfigurator>? configurator = null, [CallerFilePath]string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
         {
-            RegisterInternal(dependencyType, instanceType, configurator, constructorSelector, callerFilePath, callerLineNumber);
+            var serviceTypes = new SinglyLinkedListNode<Type>(implementationType)
+                                    .Add(serviceType);
+            RegisterInternal(serviceTypes, implementationType, configurator, callerFilePath, callerLineNumber);
+        }
+
+        /// <summary>
+        /// Registers a new weakly typed binding.
+        /// </summary>
+        /// <param name="serviceTypes"></param>
+        /// <param name="implementationType"></param>
+        /// <param name="configurator"></param>
+        /// <param name="callerFilePath"></param>
+        /// <param name="callerLineNumber"></param>
+        public void Register(Type[] serviceTypes, Type implementationType, Action<WeaklyTypedServiceConfigurator>? configurator = null, [CallerFilePath]string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+        {
+            var serviceTypes2 = new SinglyLinkedListNode<Type>(implementationType)
+                                    .Add(serviceTypes);
+            RegisterInternal(serviceTypes2, implementationType, configurator, callerFilePath, callerLineNumber);
         }
 
         /// <summary>
         /// Registers a batch of new weakly typed bindings.
         /// </summary>
-        /// <param name="dependencyType"></param>
-        /// <param name="instanceTypes"></param>
+        /// <param name="serviceType"></param>
+        /// <param name="implementationTypes"></param>
         /// <param name="configurator"></param>
-        /// <param name="constructorSelector"></param>
         /// <param name="callerFilePath"></param>
         /// <param name="callerLineNumber"></param>
         /// <returns></returns>
-        public void Register(Type dependencyType, Type[] instanceTypes, Action<WeaklyTypedServiceConfigurator>? configurator = null, IConstructorResolver? constructorSelector = null, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+        public void Register(Type serviceType, Type[] implementationTypes, Action<WeaklyTypedServiceConfigurator>? configurator = null, [CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
         {
-            foreach (Type instanceType in instanceTypes)
+            foreach (Type implementationType in implementationTypes)
             {
-                RegisterInternal(dependencyType, instanceType, configurator, constructorSelector, callerFilePath, callerLineNumber);
+                var serviceTypes = new SinglyLinkedListNode<Type>(implementationType)
+                                    .Add(serviceType);
+                RegisterInternal(serviceTypes, implementationType, configurator, callerFilePath, callerLineNumber);
             }
         }
 
 
         /// <summary>
-        /// Registers a new strongly typed decorator for <typeparamref name="TDependency"/>.
+        /// Registers a new strongly typed decorator for <typeparamref name="TService"/>.
         /// </summary>
-        /// <typeparam name="TDependency">The type to decorate</typeparam>
+        /// <typeparam name="TService">The type to decorate</typeparam>
         /// <typeparam name="TDecorator">The type of the decorator</typeparam>
-        /// <exception cref="InterfaceExpectedException">If <typeparamref name="TDependency"/> is not a interface</exception>
+        /// <exception cref="InterfaceExpectedException">If <typeparamref name="TService"/> is not a interface</exception>
         /// <returns></returns>
-        public void Decorate<TDependency, TDecorator>(Action<StronglyTypedDecoratorConfigurator<TDependency, TDecorator>>? configurator = null, IConstructorResolver? constructorSelector = null, [CallerFilePath]string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
-            where TDependency : class
-            where TDecorator : TDependency
+        public void Decorate<TService, TDecorator>(Action<StronglyTypedDecoratorConfigurator<TService, TDecorator>>? configurator = null, [CallerFilePath]string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+            where TService : class
+            where TDecorator : TService
         {
-            DecorateInternal(configurator, constructorSelector, callerFilePath, callerLineNumber);
+            DecorateInternal(configurator, callerFilePath, callerLineNumber);
         }
 
         /// <summary>
-        /// Registers a new weakly typed decorator for <paramref name="dependencyType"/>
+        /// Registers a new weakly typed decorator for <paramref name="serviceType"/>
         /// </summary>
-        /// <param name="dependencyType"></param>
+        /// <param name="serviceType"></param>
         /// <param name="decoratorType"></param>
         /// <param name="configurator"></param>
-        /// <param name="constructorSelector"></param>
         /// <param name="callerFilePath"></param>
         /// <param name="callerLineNumber"></param>
         /// <returns></returns>
-        public void Decorate(Type dependencyType, Type decoratorType, Action<WeaklyTypedDecoratorConfigurator>? configurator = null, IConstructorResolver? constructorSelector = null, [CallerFilePath]string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+        public void Decorate(Type serviceType, Type decoratorType, Action<WeaklyTypedDecoratorConfigurator>? configurator = null, [CallerFilePath]string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
         {
-            DecorateInternal(dependencyType, decoratorType, configurator, constructorSelector, callerFilePath, callerLineNumber);
+            DecorateInternal(serviceType, decoratorType, configurator, callerFilePath, callerLineNumber);
         }
 
         /// <summary>
-        /// Registers a batch of new weakly typed decorators for <paramref name="dependencyType"/>.
+        /// Registers a batch of new weakly typed decorators for <paramref name="serviceType"/>.
         /// </summary>
-        /// <param name="dependencyType"></param>
+        /// <param name="serviceType"></param>
         /// <param name="decoratorTypes"></param>
         /// <param name="configurator"></param>
-        /// <param name="constructorSelector"></param>
         /// <param name="callerFilePath"></param>
         /// <param name="callerLineNumber"></param>
         /// <returns></returns>
-        public void Decorate(Type dependencyType, Type[] decoratorTypes, Action<WeaklyTypedDecoratorConfigurator>? configurator = null, IConstructorResolver? constructorSelector = null, [CallerFilePath]string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+        public void Decorate(Type serviceType, Type[] decoratorTypes, Action<WeaklyTypedDecoratorConfigurator>? configurator = null, [CallerFilePath]string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
         {
             foreach (Type decoratorType in decoratorTypes)
             {
-                DecorateInternal(dependencyType, decoratorType, configurator, constructorSelector, callerFilePath, callerLineNumber);
+                DecorateInternal(serviceType, decoratorType, configurator, callerFilePath, callerLineNumber);
             }
         }
 
@@ -191,43 +254,42 @@ namespace Singularity
             LateInjectInternal(instanceType, configurator, callerFilePath, callerLineNumber);
         }
 
-        private void RegisterInternal<TDependency, TInstance>(Action<StronglyTypedServiceConfigurator<TDependency, TInstance>>? configurator, IConstructorResolver? constructorSelector, string callerFilePath, int callerLineNumber)
-            where TInstance : class, TDependency
+        private void RegisterInternal<TImplementation>(Action<StronglyTypedServiceConfigurator<TImplementation>>? configurator, SinglyLinkedListNode<Type> serviceTypes, string callerFilePath, int callerLineNumber)
         {
             var metadata = new BindingMetadata(callerFilePath, callerLineNumber, Registrations.CurrentModule);
-            var context = new StronglyTypedServiceConfigurator<TDependency, TInstance>(metadata, Settings, constructorSelector);
+            var context = new StronglyTypedServiceConfigurator<TImplementation>(metadata, serviceTypes, Settings);
             configurator?.Invoke(context);
             ServiceBinding serviceBinding = context.ToBinding();
             Registrations.AddBinding(serviceBinding);
         }
 
-        private void RegisterInternal(Type dependencyType, Type instanceType, Action<WeaklyTypedServiceConfigurator>? configurator, IConstructorResolver? constructorSelector, string callerFilePath, int callerLineNumber)
+        private void RegisterInternal(SinglyLinkedListNode<Type> serviceTypes, Type implementationType, Action<WeaklyTypedServiceConfigurator>? configurator, string callerFilePath, int callerLineNumber)
         {
             var metadata = new BindingMetadata(callerFilePath, callerLineNumber, Registrations.CurrentModule);
-            var context = new WeaklyTypedServiceConfigurator(dependencyType, instanceType, metadata, Settings, constructorSelector);
+            var context = new WeaklyTypedServiceConfigurator(serviceTypes, implementationType, metadata, Settings);
             configurator?.Invoke(context);
             ServiceBinding serviceBinding = context.ToBinding();
             Registrations.AddBinding(serviceBinding);
         }
 
-        private void DecorateInternal<TDependency, TDecorator>(Action<StronglyTypedDecoratorConfigurator<TDependency, TDecorator>>? configurator, IConstructorResolver? constructorSelector, string callerFilePath, int callerLineNumber)
-            where TDependency : class
-            where TDecorator : TDependency
+        private void DecorateInternal<TService, TDecorator>(Action<StronglyTypedDecoratorConfigurator<TService, TDecorator>>? configurator, string callerFilePath, int callerLineNumber)
+            where TService : class
+            where TDecorator : TService
         {
             var metadata = new BindingMetadata(callerFilePath, callerLineNumber, Registrations.CurrentModule);
-            var context = new StronglyTypedDecoratorConfigurator<TDependency, TDecorator>(metadata, Settings, constructorSelector);
+            var context = new StronglyTypedDecoratorConfigurator<TService, TDecorator>(metadata, Settings);
             configurator?.Invoke(context);
             Expression binding = context.ToBinding();
-            Registrations.AddDecorator(typeof(TDependency), binding);
+            Registrations.AddDecorator(typeof(TService), binding);
         }
 
-        private void DecorateInternal(Type dependencyType, Type decoratorType, Action<WeaklyTypedDecoratorConfigurator>? configurator, IConstructorResolver? constructorSelector, string callerFilePath, int callerLineNumber)
+        private void DecorateInternal(Type serviceType, Type decoratorType, Action<WeaklyTypedDecoratorConfigurator>? configurator, string callerFilePath, int callerLineNumber)
         {
             var metadata = new BindingMetadata(callerFilePath, callerLineNumber, Registrations.CurrentModule);
-            var context = new WeaklyTypedDecoratorConfigurator(dependencyType, decoratorType, metadata, Settings, constructorSelector);
+            var context = new WeaklyTypedDecoratorConfigurator(serviceType, decoratorType, metadata, Settings);
             configurator?.Invoke(context);
             Expression binding = context.ToBinding();
-            Registrations.AddDecorator(dependencyType, binding);
+            Registrations.AddDecorator(serviceType, binding);
         }
 
         private void LateInjectInternal<TInstance>(Action<StronglyTypedLateInjectorConfigurator<TInstance>>? configurator, string callerFilePath, int callerLineNumber)

--- a/src/Singularity/Expressions/DecoratorExpressionVisitor.cs
+++ b/src/Singularity/Expressions/DecoratorExpressionVisitor.cs
@@ -9,24 +9,24 @@ namespace Singularity.Expressions
     internal sealed class DecoratorExpressionVisitor : ExpressionVisitor
     {
         private readonly InstanceFactory[] _factories;
-        private readonly Type _instanceType;
+        private readonly Type _serviceType;
         public Expression? PreviousDecorator;
 
-        public DecoratorExpressionVisitor(InstanceFactory[] factories, Type instanceType)
+        public DecoratorExpressionVisitor(InstanceFactory[] factories, Type serviceType)
         {
             _factories = factories;
-            _instanceType = instanceType;
+            _serviceType = serviceType;
         }
 
         protected override Expression VisitParameter(ParameterExpression node)
         {
-            if (node.Type == _instanceType)
+            if (node.Type == _serviceType)
             {
                 return PreviousDecorator ?? throw new InvalidOperationException($"You should assign {nameof(PreviousDecorator)} first");
             }
             else
             {
-                InstanceFactory factory = _factories.First(x => x.DependencyType == node.Type);
+                InstanceFactory factory = _factories.First(x => x.ServiceType == node.Type);
                 return factory.Context.Expression;
             }
         }

--- a/src/Singularity/Expressions/ExpressionGenerator.cs
+++ b/src/Singularity/Expressions/ExpressionGenerator.cs
@@ -42,14 +42,14 @@ namespace Singularity.Expressions
                    serviceBinding.NeedsDispose != ServiceAutoDispose.Never && typeof(IDisposable).IsAssignableFrom(context.Expression.Type) && settings.AutoDisposeLifetimes.Contains(serviceBinding.Lifetime.GetType());
         }
 
-        public ReadOnlyExpressionContext ApplyDecorators(Type dependencyType, ServiceBinding serviceBinding, InstanceFactory[] children, Expression[] decorators, Scoped containerScope)
+        public ReadOnlyExpressionContext ApplyDecorators(Type serviceType, ServiceBinding serviceBinding, InstanceFactory[] children, Expression[] decorators, Scoped containerScope)
         {
             ExpressionContext context = (ExpressionContext)(serviceBinding.BaseExpression ?? throw new ArgumentNullException($"{nameof(serviceBinding)}.{nameof(serviceBinding.BaseExpression)}"));
             if (decorators.Length > 0)
             {
                 var body = new List<Expression>();
-                ParameterExpression instanceParameter = Expression.Variable(dependencyType, $"{dependencyType} instance");
-                body.Add(Expression.Assign(instanceParameter, Expression.Convert(context.Expression, dependencyType)));
+                ParameterExpression instanceParameter = Expression.Variable(serviceType, $"{serviceType} instance");
+                body.Add(Expression.Assign(instanceParameter, Expression.Convert(context.Expression, serviceType)));
 
                 var decoratorExpressionVisitor = new DecoratorExpressionVisitor(children, instanceParameter.Type);
                 decoratorExpressionVisitor.PreviousDecorator = instanceParameter;

--- a/src/Singularity/Expressions/ParameterExpressionVisitor.cs
+++ b/src/Singularity/Expressions/ParameterExpressionVisitor.cs
@@ -18,7 +18,7 @@ namespace Singularity.Expressions
         protected override Expression VisitParameter(ParameterExpression node)
         {
             if (node.Type == typeof(Scoped)) return ExpressionGenerator.ScopeParameter;
-            InstanceFactory factory = _factories.First(x => x.DependencyType == node.Type);
+            InstanceFactory factory = _factories.First(x => x.ServiceType == node.Type);
             if (factory.Context.Expression is MethodCallExpression methodCallExpression && methodCallExpression.Method.IsGenericMethod && methodCallExpression.Method.GetGenericMethodDefinition() == Scoped.GetOrAddScopedInstanceMethod)
             {
                 _context.ScopedExpressions.Add(methodCallExpression);

--- a/src/Singularity/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/Singularity/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -42,6 +43,7 @@ namespace Singularity.FastExpressionCompiler
     /// <summary>Compiles expression to delegate ~20 times faster than Expression.Compile.
     /// Partial to extend with your things when used as source file.</summary>
     // ReSharper disable once PartialTypeWithSinglePart
+    [ExcludeFromCodeCoverage]
     internal static partial class ExpressionCompiler
     {
         #region Expression.CompileFast overloads for Delegate, Funcs, and Actions
@@ -3446,6 +3448,7 @@ namespace Singularity.FastExpressionCompiler
 
     // Helpers targeting the performance. Extensions method names may be a bit funny (non standard),
     // in order to prevent conflicts with YOUR helpers with standard names
+    [ExcludeFromCodeCoverage]
     internal static class Tools
     {
         internal static bool IsValueType(this Type type) => type.GetTypeInfo().IsValueType;

--- a/src/Singularity/Registration/ServiceBinding.cs
+++ b/src/Singularity/Registration/ServiceBinding.cs
@@ -83,7 +83,7 @@ namespace Singularity
         /// <returns></returns>
         public bool TryGetInstanceFactory(Type type, out InstanceFactory factory)
         {
-            factory = Factories.Array.FirstOrDefault(x => x.DependencyType == type);
+            factory = Factories.Array.FirstOrDefault(x => x.ServiceType == type);
             return factory != null;
         }
 
@@ -111,9 +111,9 @@ namespace Singularity
         /// </summary>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="InvalidEnumValueException{T}"></exception>
-        public ServiceBinding(Type[] dependencyTypes, in BindingMetadata bindingMetadata, Expression? expression, Type concreteType, IConstructorResolver constructorResolver,
+        public ServiceBinding(Type[] serviceTypes, in BindingMetadata bindingMetadata, Expression? expression, Type concreteType, IConstructorResolver constructorResolver,
             ILifetime lifetime, Action<object>? finalizer = null,
-            ServiceAutoDispose needsDispose = ServiceAutoDispose.Default) : this(dependencyTypes.ToSinglyLinkedList() ?? throw new ArgumentException("there should be atleast 1 dependency type", nameof(dependencyTypes)), bindingMetadata, expression, concreteType, constructorResolver, lifetime, finalizer, needsDispose)
+            ServiceAutoDispose needsDispose = ServiceAutoDispose.Default) : this(serviceTypes.ToSinglyLinkedList() ?? throw new ArgumentException("there should be atleast 1 dependency type", nameof(serviceTypes)), bindingMetadata, expression, concreteType, constructorResolver, lifetime, finalizer, needsDispose)
         {
         }
 
@@ -122,9 +122,9 @@ namespace Singularity
         /// </summary>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="InvalidEnumValueException{T}"></exception>
-        public ServiceBinding(Type dependencyType, in BindingMetadata bindingMetadata, Expression? expression, Type concreteType, IConstructorResolver constructorResolver,
+        public ServiceBinding(Type serviceType, in BindingMetadata bindingMetadata, Expression? expression, Type concreteType, IConstructorResolver constructorResolver,
             ILifetime lifetime, Action<object>? finalizer = null,
-            ServiceAutoDispose needsDispose = ServiceAutoDispose.Default) : this(new SinglyLinkedListNode<Type>(dependencyType), bindingMetadata, expression, concreteType, constructorResolver, lifetime, finalizer, needsDispose)
+            ServiceAutoDispose needsDispose = ServiceAutoDispose.Default) : this(new SinglyLinkedListNode<Type>(serviceType), bindingMetadata, expression, concreteType, constructorResolver, lifetime, finalizer, needsDispose)
         {
         }
     }

--- a/src/Singularity/Registration/WeaklyTypedDecoratorConfigurator.cs
+++ b/src/Singularity/Registration/WeaklyTypedDecoratorConfigurator.cs
@@ -10,22 +10,36 @@ namespace Singularity
     /// </summary>
     public sealed class WeaklyTypedDecoratorConfigurator
     {
-        internal WeaklyTypedDecoratorConfigurator(Type dependencyType, Type decoratorType, in BindingMetadata bindingMetadata, SingularitySettings settings, IConstructorResolver? constructorSelector)
+        internal WeaklyTypedDecoratorConfigurator(Type serviceType, Type decoratorType, in BindingMetadata bindingMetadata, SingularitySettings settings)
         {
             _bindingMetadata = bindingMetadata;
-            _dependencyType = dependencyType;
-            _expression = (constructorSelector ?? settings.ConstructorResolver).ResolveConstructorExpression(decoratorType);
-            DecoratorTypeValidator.CheckIsInterface(dependencyType);
-            DecoratorTypeValidator.CheckParameters(_expression, dependencyType, decoratorType);
+            _serviceType = serviceType;
+            _settings = settings;
+            _decoratorType = decoratorType;
+            DecoratorTypeValidator.CheckIsInterface(serviceType);
         }
 
         private readonly BindingMetadata _bindingMetadata;
-        private readonly Type _dependencyType;
-        private readonly Expression _expression;
+        private readonly Type _serviceType;
+        private readonly Type _decoratorType;
+        private readonly SingularitySettings _settings;
+        private IConstructorResolver? _constructorSelector;
+
+        /// <summary>
+        /// Overrides the default constructor selector for this decorator
+        /// <param name="value"></param>
+        /// </summary>
+        public WeaklyTypedDecoratorConfigurator With(IConstructorResolver value)
+        {
+            _constructorSelector = value;
+            return this;
+        }
 
         internal Expression ToBinding()
         {
-            return _expression;
+            var expression = (_constructorSelector ?? _settings.ConstructorResolver).ResolveConstructorExpression(_decoratorType);
+            DecoratorTypeValidator.CheckParameters(expression, _serviceType, _decoratorType);
+            return expression;
         }
     }
 }

--- a/src/Singularity/Resolving/Generators/ExpressionServiceBindingGenerator.cs
+++ b/src/Singularity/Resolving/Generators/ExpressionServiceBindingGenerator.cs
@@ -23,8 +23,8 @@ namespace Singularity.Resolving.Generators
                 Type funcType = type.GenericTypeArguments[0];
                 if (funcType.GetGenericTypeDefinition() == typeof(Func<>) && funcType.GenericTypeArguments.Length == 1)
                 {
-                    Type dependencyType = funcType.GenericTypeArguments[0];
-                    MethodInfo resolveMethod = GenericResolveMethod.MakeGenericMethod(dependencyType);
+                    Type serviceType = funcType.GenericTypeArguments[0];
+                    MethodInfo resolveMethod = GenericResolveMethod.MakeGenericMethod(serviceType);
 
                     var bindings = (IEnumerable<ServiceBinding>)resolveMethod.Invoke(this, new object[] { resolver, type });
                     foreach (var binding in bindings)

--- a/src/Singularity/Resolving/Generators/FactoryServiceBindingGenerator.cs
+++ b/src/Singularity/Resolving/Generators/FactoryServiceBindingGenerator.cs
@@ -16,9 +16,9 @@ namespace Singularity.Resolving.Generators
         {
             if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Func<>))
             {
-                Type dependencyType = type.GenericTypeArguments[0];
+                Type serviceType = type.GenericTypeArguments[0];
 
-                foreach (InstanceFactory factory in resolver.TryResolveAll(dependencyType))
+                foreach (InstanceFactory factory in resolver.TryResolveAll(serviceType))
                 {
                     LambdaExpression baseExpression = Expression.Lambda(factory.Context.Expression);
 

--- a/src/Singularity/Resolving/InstanceFactory.cs
+++ b/src/Singularity/Resolving/InstanceFactory.cs
@@ -12,7 +12,7 @@ namespace Singularity.Resolving
         /// <summary>
         /// The service type.
         /// </summary>
-        public Type DependencyType { get; }
+        public Type ServiceType { get; }
 
         /// <summary>
         /// Expression that is used to create the instance of the service
@@ -29,12 +29,12 @@ namespace Singularity.Resolving
         /// <summary>
         /// Creates a new <see cref="InstanceFactory"/>
         /// </summary>
-        /// <param name="dependencyType"></param>
+        /// <param name="serviceType"></param>
         /// <param name="context"></param>
         /// <param name="factory"></param>
-        public InstanceFactory(Type dependencyType, ReadOnlyExpressionContext context, Func<Scoped, object>? factory = null)
+        public InstanceFactory(Type serviceType, ReadOnlyExpressionContext context, Func<Scoped, object>? factory = null)
         {
-            DependencyType = dependencyType;
+            ServiceType = serviceType;
             Context = context;
             _factory = factory;
         }

--- a/src/Singularity/Singularity.csproj
+++ b/src/Singularity/Singularity.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>The core library for the singularity ioc container</Description>
     <PackageTags>ioc di inversion control dependency injection container</PackageTags>
-    <WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
+    <WarningsAsErrors>CS8600;CS8602;CS8603;CS8604</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Singularity/Utils/DecoratorTypeValidator.cs
+++ b/src/Singularity/Utils/DecoratorTypeValidator.cs
@@ -8,15 +8,15 @@ namespace Singularity
 {
     internal static class DecoratorTypeValidator
     {
-        public static void CheckIsInterface(Type dependencyType)
+        public static void CheckIsInterface(Type serviceType)
         {
-            if (!dependencyType.GetTypeInfo().IsInterface) throw new InterfaceExpectedException($"{dependencyType} is not a interface.");
+            if (!serviceType.GetTypeInfo().IsInterface) throw new InterfaceExpectedException($"{serviceType} is not a interface.");
         }
 
-        public static void CheckParameters(Expression expression, Type dependencyType, Type decoratorType)
+        public static void CheckParameters(Expression expression, Type serviceType, Type decoratorType)
         {
             ParameterExpression[] parameters = expression.GetParameterExpressions();
-            if (parameters.All(x => x.Type != dependencyType)) throw new InvalidExpressionArgumentsException($"Cannot decorate {dependencyType} since the expression to create {decoratorType} does not have a parameter for {dependencyType}");
+            if (parameters.All(x => x.Type != serviceType)) throw new InvalidExpressionArgumentsException($"Cannot decorate {serviceType} since the expression to create {decoratorType} does not have a parameter for {serviceType}");
         }
     }
 }

--- a/src/Singularity/Utils/ServiceTypeValidator.cs
+++ b/src/Singularity/Utils/ServiceTypeValidator.cs
@@ -8,44 +8,44 @@ namespace Singularity
 {
     internal static class ServiceTypeValidator
     {
-        public static void CheckIsEnumerable(Type dependencyType)
+        public static void CheckIsEnumerable(Type serviceType)
         {
-            if (IsEnumerable(dependencyType))
-                ThrowEnumerableRegistrationException(dependencyType);
+            if (IsEnumerable(serviceType))
+                ThrowEnumerableRegistrationException(serviceType);
         }
 
-        public static void CheckIsAssignable(Type dependencyType, Type instanceType)
+        public static void CheckIsAssignable(Type serviceType, Type implementationType)
         {
-            if (dependencyType.ContainsGenericParameters)
+            if (serviceType.ContainsGenericParameters)
             {
-                if (!instanceType.ContainsGenericParameters || instanceType.GenericTypeArguments.Length != dependencyType.GenericTypeArguments.Length)
+                if (!implementationType.ContainsGenericParameters || implementationType.GenericTypeArguments.Length != serviceType.GenericTypeArguments.Length)
                 {
-                    throw new TypeNotAssignableException($"Open generic type {dependencyType} is not implemented by {instanceType}");
+                    throw new TypeNotAssignableException($"Open generic type {serviceType} is not implemented by {implementationType}");
                 }
             }
             else
             {
-                if (!dependencyType.IsAssignableFrom(instanceType)) throw new TypeNotAssignableException($"{dependencyType} is not implemented by {instanceType}");
+                if (!serviceType.IsAssignableFrom(implementationType)) throw new TypeNotAssignableException($"{serviceType} is not implemented by {implementationType}");
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void CheckIsAssignable(SinglyLinkedListNode<Type> dependencyTypes, Type instanceType)
+        public static void CheckIsAssignable(SinglyLinkedListNode<Type> serviceTypes, Type implementationType)
         {
-            foreach (Type dependencyType in dependencyTypes)
+            foreach (Type serviceType in serviceTypes)
             {
-                CheckIsAssignable(dependencyType, instanceType);
+                CheckIsAssignable(serviceType, implementationType);
             }
         }
 
-        private static void ThrowEnumerableRegistrationException(Type dependencyType)
+        private static void ThrowEnumerableRegistrationException(Type serviceType)
         {
-            throw new EnumerableRegistrationException($"don't register {dependencyType} as IEnumerable directly. Instead register them as you would normally.");
+            throw new EnumerableRegistrationException($"don't register {serviceType} as IEnumerable directly. Instead register them as you would normally.");
         }
 
-        private static bool IsEnumerable(Type dependencyType)
+        private static bool IsEnumerable(Type serviceType)
         {
-            if (dependencyType.IsGenericType && dependencyType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            if (serviceType.IsGenericType && serviceType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
             {
                 return true;
             }

--- a/src/Tests/Singularity.Microsoft.DependencyInjection.Test/ContainerBuilderTests.cs
+++ b/src/Tests/Singularity.Microsoft.DependencyInjection.Test/ContainerBuilderTests.cs
@@ -22,10 +22,11 @@ namespace Singularity.Microsoft.DependencyInjection.Test
 
             RegistrationStore registrationStore = builder.Registrations;
 
-            KeyValuePair<Type, Registration> registration = Assert.Single(registrationStore.Registrations);
+            Assert.Equal(2, registrationStore.Registrations.Count);
+
+            var registration = registrationStore.Registrations[typeof(IRepositoryTransient1)];
             Assert.Empty(registrationStore.Decorators);
-            ServiceBinding serviceBinding = Assert.Single(registration.Value.Bindings);
-            Assert.Equal(typeof(IRepositoryTransient1), registration.Key);
+            ServiceBinding serviceBinding = Assert.Single(registration.Bindings);
             Assert.Equal(typeof(RepositoryTransient1), serviceBinding.Expression?.Type);
         }
     }

--- a/src/Tests/Singularity.Test/Injection/ChildContainerTests.cs
+++ b/src/Tests/Singularity.Test/Injection/ChildContainerTests.cs
@@ -35,7 +35,7 @@ namespace Singularity.Test.Injection
             //ARRANGE
             var container = new Container(builder =>
             {
-                builder.Register<IDisposable, Disposable>(c => c.As<Disposable>().With(Lifetimes.PerContainer).With(ServiceAutoDispose.Always));
+                builder.Register<IDisposable, Disposable>(c => c.With(Lifetimes.PerContainer).With(ServiceAutoDispose.Always));
             });
 
             //ACT
@@ -59,7 +59,7 @@ namespace Singularity.Test.Injection
             //ARRANGE
             var container = new Container(builder =>
             {
-                builder.Register<IDisposable, Disposable>(c => c.As<Disposable>().With(Lifetimes.PerScope).With(ServiceAutoDispose.Always));
+                builder.Register<IDisposable, Disposable>(c => c.With(Lifetimes.PerScope).With(ServiceAutoDispose.Always));
             });
 
             //ACT
@@ -85,7 +85,7 @@ namespace Singularity.Test.Injection
             //ARRANGE
             var container = new Container(builder =>
             {
-                builder.Register<ISingleton1, Singleton1>(c => c.As<Singleton1>().With(Lifetimes.PerContainer));
+                builder.Register<ISingleton1, Singleton1>(c => c.With(Lifetimes.PerContainer));
             });
 
             //ACT
@@ -106,7 +106,7 @@ namespace Singularity.Test.Injection
             //ARRANGE
             var container = new Container(builder =>
             {
-                builder.Register<ISingleton1, Singleton1>(c => c.As<Singleton1>().With(Lifetimes.PerContainer));
+                builder.Register<ISingleton1, Singleton1>(c => c.With(Lifetimes.PerContainer));
             });
 
             //ACT
@@ -127,7 +127,7 @@ namespace Singularity.Test.Injection
             //ARRANGE
             var container = new Container(builder =>
             {
-                builder.Register<ISingleton1, Singleton1>(c => c.As<Singleton1>().With(Lifetimes.PerScope));
+                builder.Register<ISingleton1, Singleton1>(c => c.With(Lifetimes.PerScope));
             });
 
             //ACT
@@ -149,7 +149,7 @@ namespace Singularity.Test.Injection
             //ARRANGE
             var container = new Container(builder =>
             {
-                builder.Register<ISingleton1, Singleton1>(c => c.As<Singleton1>().With(Lifetimes.PerScope));
+                builder.Register<ISingleton1, Singleton1>(c => c.With(Lifetimes.PerScope));
             });
 
             //ACT

--- a/src/Tests/Singularity.Test/Injection/MultiInterfaceSameImplementationTests.cs
+++ b/src/Tests/Singularity.Test/Injection/MultiInterfaceSameImplementationTests.cs
@@ -9,29 +9,12 @@ namespace Singularity.Test.Injection
     public class MultiInterfaceSameImplementationTests
     {
         [Fact]
-        public void GetInstance_WrongInterfaceType_Throws()
-        {
-            //ARRANGE
-            //ACT
-            //ASSERT
-            Assert.Throws<TypeNotAssignableException>(() =>
-            {
-                var container = new Container(builder =>
-                {
-                    builder.Register<IService1, Implementation1>(c => c
-                        .As<ITestService10>());
-                });
-            });
-        }
-
-        [Fact]
         public void GetInstance_2Interfaces_ReturnsCorrectDependency()
         {
             //ARRANGE
             var container = new Container(builder =>
             {
-                builder.Register<IService1, Implementation1>(c => c
-                    .As<IService2>());
+                builder.Register<IService1, IService2, Implementation1>();
             });
 
             //ACT
@@ -54,9 +37,7 @@ namespace Singularity.Test.Injection
             //ARRANGE
             var container = new Container(builder =>
             {
-                builder.Register<IService1, Implementation1>(c => c
-                    .As<IService2>()
-                    .As<IService3>());
+                builder.Register<IService1, IService2, IService3, Implementation1>();
             });
 
             //ACT
@@ -82,9 +63,7 @@ namespace Singularity.Test.Injection
             //ARRANGE
             var container = new Container(builder =>
             {
-                builder.Register<IService1, Implementation1>(c => c
-                    .As<IService2>()
-                    .As<IService3>());
+                builder.Register<IService1, IService2, IService3, Implementation1>();
                 builder.Decorate<IService2, Service2Decorator>();
             });
 
@@ -112,9 +91,7 @@ namespace Singularity.Test.Injection
             var container = new Container(builder =>
             {
                 builder.Register<IService1, Implementation2>();
-                builder.Register<IService1, Implementation1>(c => c
-                    .As<IService2>()
-                    .As<IService3>());
+                builder.Register<IService1, IService2, IService3, Implementation1>();
                 builder.Decorate<IService1, Service1Decorator>();
                 builder.Decorate<IService2, Service2Decorator>();
             });
@@ -151,10 +128,10 @@ namespace Singularity.Test.Injection
             var container = new Container(builder =>
             {
                 builder.Register<IService1, Implementation2>();
-                builder.Register<IService1, Implementation1>(c => c
-                    .As<IService2>()
-                    .As<IService3>()
-                    .With(Lifetimes.PerContainer));
+                builder.Register<IService1, IService2, IService3, Implementation1>(c =>
+                {
+                    c.With(Lifetimes.PerContainer);
+                });
                 builder.Decorate<IService1, Service1Decorator>();
                 builder.Decorate<IService2, Service2Decorator>();
             });
@@ -190,9 +167,7 @@ namespace Singularity.Test.Injection
             //ARRANGE
             var container = new Container(builder =>
             {
-                builder.Register(typeof(IService1), typeof(Implementation1), c => c
-                    .As(typeof(IService2))
-                    .As(typeof(IService3)));
+                builder.Register(new[] { typeof(IService1), typeof(IService2), typeof(IService3) }, typeof(Implementation1));
             });
 
             //ACT
@@ -218,11 +193,10 @@ namespace Singularity.Test.Injection
             //ARRANGE
             var container = new Container(builder =>
             {
-                builder.Register<IService1, Implementation1>(c => c
-                    .As<IService2>()
-                    .As<IService3>()
-                    .As<Implementation1>()
-                    .With(Lifetimes.PerContainer));
+                builder.Register<IService1, IService2, IService3, Implementation1>(c =>
+                {
+                    c.With(Lifetimes.PerContainer);
+                });
             });
 
             //ACT
@@ -248,10 +222,7 @@ namespace Singularity.Test.Injection
             //ARRANGE
             var container = new Container(builder =>
             {
-                builder.Register(typeof(IService1), typeof(Implementation1), c => c
-                    .As(typeof(IService2))
-                    .As(typeof(IService3))
-                    .As(typeof(Implementation1))
+                builder.Register(new[] { typeof(IService1), typeof(IService2), typeof(IService3) }, typeof(Implementation1), c => c
                     .With(Lifetimes.PerContainer));
             });
 

--- a/src/Tests/Singularity.Test/Injection/MultiInterfaceSameImplementationTests.cs
+++ b/src/Tests/Singularity.Test/Injection/MultiInterfaceSameImplementationTests.cs
@@ -32,6 +32,29 @@ namespace Singularity.Test.Injection
         }
 
         [Fact]
+        public void GetInstance_2Interfaces_PerContainerLifetime_ReturnsSameInstance()
+        {
+            //ARRANGE
+            var container = new Container(builder =>
+            {
+                builder.Register<IService1, IService2, Implementation1>(c => c.With(Lifetimes.PerContainer));
+            });
+
+            //ACT
+            var value1 = container.GetInstance<IService1>();
+            var value2 = container.GetInstance<IService2>();
+            var value3 = container.GetInstance<Implementation1>();
+
+            //ASSERT
+            Assert.IsType<Implementation1>(value1);
+            Assert.IsType<Implementation1>(value2);
+            Assert.IsType<Implementation1>(value3);
+
+            Assert.Same(value1, value2);
+            Assert.Same(value1, value3);
+        }
+
+        [Fact]
         public void GetInstance_3Interfaces_ReturnsCorrectDependency()
         {
             //ARRANGE
@@ -55,6 +78,35 @@ namespace Singularity.Test.Injection
             Assert.NotSame(value1, value2);
             Assert.NotSame(value1, value3);
             Assert.NotSame(value1, value4);
+        }
+
+        [Fact]
+        public void GetInstance_4Interfaces_ReturnsCorrectDependency()
+        {
+            //ARRANGE
+            var container = new Container(builder =>
+            {
+                builder.Register<IService1, IService2, IService3, IService4, Implementation1>();
+            });
+
+            //ACT
+            var value1 = container.GetInstance<IService1>();
+            var value2 = container.GetInstance<IService2>();
+            var value3 = container.GetInstance<IService3>();
+            var value4 = container.GetInstance<IService4>();
+            var value5 = container.GetInstance<Implementation1>();
+
+            //ASSERT
+            Assert.IsType<Implementation1>(value1);
+            Assert.IsType<Implementation1>(value2);
+            Assert.IsType<Implementation1>(value3);
+            Assert.IsType<Implementation1>(value4);
+            Assert.IsType<Implementation1>(value5);
+
+            Assert.NotSame(value1, value2);
+            Assert.NotSame(value1, value3);
+            Assert.NotSame(value1, value4);
+            Assert.NotSame(value1, value5);
         }
 
         [Fact]

--- a/src/Tests/Singularity.Test/Registrations/ContainerBuilderTests.cs
+++ b/src/Tests/Singularity.Test/Registrations/ContainerBuilderTests.cs
@@ -38,10 +38,13 @@ namespace Singularity.Test.Registrations
             KeyValuePair<Type, Registration>[] registrations = builder.Registrations.Registrations.ToArray();
 
             //ASSERT
-            Assert.Equal(3, registrations.Length);
+            Assert.Equal(6, registrations.Length);
             Assert.Equal(typeof(ITestService10), registrations[0].Key);
-            Assert.Equal(typeof(ITestService11), registrations[1].Key);
-            Assert.Equal(typeof(ITestService12), registrations[2].Key);
+            Assert.Equal(typeof(TestService10), registrations[1].Key);
+            Assert.Equal(typeof(ITestService11), registrations[2].Key);
+            Assert.Equal(typeof(TestService11), registrations[3].Key);
+            Assert.Equal(typeof(ITestService12), registrations[4].Key);
+            Assert.Equal(typeof(TestService12), registrations[5].Key);
         }
 
         [Fact]
@@ -50,6 +53,7 @@ namespace Singularity.Test.Registrations
             //ARRANGE
             var builder = new ContainerBuilder(cb =>
             {
+                //ACT
                 cb.Register(typeof(IPlugin), new[]
                 {
                     typeof(Plugin1),
@@ -58,14 +62,26 @@ namespace Singularity.Test.Registrations
                 });
             });
 
-            //ACT
-            Registration[] registrations = builder.Registrations.Registrations.Values.ToArray();
-
             //ASSERT
-            ServiceBinding[] serviceBindings = Assert.Single(registrations).Bindings.ToArray();
+            var registrations = builder.Registrations.Registrations;
+
+            Assert.Equal(4, registrations.Count());
+
+            var multiServiceBinding = registrations[typeof(IPlugin)];
+
+            ServiceBinding[] serviceBindings = multiServiceBinding.Bindings.ToArray();
             Assert.Equal(typeof(Plugin1), serviceBindings[0].Expression?.Type);
             Assert.Equal(typeof(Plugin2), serviceBindings[1].Expression?.Type);
             Assert.Equal(typeof(Plugin3), serviceBindings[2].Expression?.Type);
+
+            var plugin1Binding = registrations[typeof(Plugin1)];
+            Assert.Single(plugin1Binding.Bindings);
+
+            var plugin2Binding = registrations[typeof(Plugin2)];
+            Assert.Single(plugin2Binding.Bindings);
+
+            var plugin3Binding = registrations[typeof(Plugin3)];
+            Assert.Single(plugin3Binding.Bindings);
         }
 
         [Fact]
@@ -74,6 +90,7 @@ namespace Singularity.Test.Registrations
             //ARRANGE
             var builder = new ContainerBuilder(cb =>
             {
+                //ACT
                 cb.Register(typeof(IPlugin), new[]
                 {
                     typeof(Plugin1),
@@ -83,15 +100,29 @@ namespace Singularity.Test.Registrations
                     .With(Lifetimes.PerContainer));
             });
 
-            //ACT
-            Registration[] registrations = builder.Registrations.Registrations.Values.ToArray();
 
             //ASSERT
-            ServiceBinding[] serviceBindings = Assert.Single(registrations).Bindings.ToArray();
+            var registrations = builder.Registrations.Registrations;
+
+            Assert.Equal(4, registrations.Count());
+
+            var multiServiceBinding = registrations[typeof(IPlugin)];
+
+            ServiceBinding[] serviceBindings = multiServiceBinding.Bindings.ToArray();
             Assert.Equal(typeof(Plugin1), serviceBindings[0].Expression?.Type);
             Assert.Equal(typeof(Plugin2), serviceBindings[1].Expression?.Type);
             Assert.Equal(typeof(Plugin3), serviceBindings[2].Expression?.Type);
-            Assert.True(registrations[0].Bindings.All(x => x.Lifetime == Lifetimes.PerContainer));
+
+            var plugin1Binding = registrations[typeof(Plugin1)];
+            Assert.Single(plugin1Binding.Bindings);
+
+            var plugin2Binding = registrations[typeof(Plugin2)];
+            Assert.Single(plugin2Binding.Bindings);
+
+            var plugin3Binding = registrations[typeof(Plugin3)];
+            Assert.Single(plugin3Binding.Bindings);
+
+            Assert.True(registrations.Values.All(x => x.Bindings.All(y => y.Lifetime == Lifetimes.PerContainer)));
         }
 
         [Fact]
@@ -116,10 +147,24 @@ namespace Singularity.Test.Registrations
             RegistrationStore readOnlyBindingConfig = builder.Registrations;
 
             //ASSERT
-            ServiceBinding[] serviceBindings = Assert.Single(readOnlyBindingConfig.Registrations).Value.Bindings.ToArray();
+
+            Assert.Equal(4, readOnlyBindingConfig.Registrations.Count());
+
+            var multiServiceBinding = readOnlyBindingConfig.Registrations[typeof(IPlugin)];
+
+            ServiceBinding[] serviceBindings = multiServiceBinding.Bindings.ToArray();
             Assert.Equal(typeof(Plugin1), serviceBindings[0].Expression?.Type);
             Assert.Equal(typeof(Plugin2), serviceBindings[1].Expression?.Type);
             Assert.Equal(typeof(Plugin3), serviceBindings[2].Expression?.Type);
+
+            var plugin1Binding = readOnlyBindingConfig.Registrations[typeof(Plugin1)];
+            Assert.Single(plugin1Binding.Bindings);
+
+            var plugin2Binding = readOnlyBindingConfig.Registrations[typeof(Plugin2)];
+            Assert.Single(plugin2Binding.Bindings);
+
+            var plugin3Binding = readOnlyBindingConfig.Registrations[typeof(Plugin3)];
+            Assert.Single(plugin3Binding.Bindings);
 
             ArrayList<Expression> decorators = Assert.Single(readOnlyBindingConfig.Decorators.Values);
 
@@ -193,7 +238,7 @@ namespace Singularity.Test.Registrations
         {
             var builder = new ContainerBuilder(cb =>
             {
-                cb.Register(typeof(object),c => c.Inject(Expression.Constant(new object())));
+                cb.Register(typeof(object), c => c.Inject(Expression.Constant(new object())));
             });
 
             KeyValuePair<Type, Registration> registration = Assert.Single(builder.Registrations.Registrations);

--- a/src/Tests/Singularity.TestClasses/TestClasses/MultiInterfaceSameImplementation.cs
+++ b/src/Tests/Singularity.TestClasses/TestClasses/MultiInterfaceSameImplementation.cs
@@ -2,16 +2,18 @@
 
 namespace Singularity.TestClasses.TestClasses
 {
-    public class Implementation1 : IService1, IService2, IService3
+    public class Implementation1 : IService1, IService2, IService3, IService4
     {
     }
 
-    public class Implementation2 : IService1, IService2, IService3
+    public class Implementation2 : IService1, IService2, IService3, IService4
     {
     }
 
     public interface IService1 { }
     public interface IService2 { }
+    public interface IService3 { }
+    public interface IService4 { }
 
     public class Service1Decorator : IService1
     {
@@ -30,6 +32,4 @@ namespace Singularity.TestClasses.TestClasses
             Service = service ?? throw new ArgumentNullException(nameof(service));
         }
     }
-    public interface IService3 { }
-
 }


### PR DESCRIPTION
Removed As method and replaced it with a different api with more safety, cleaned up naming for services and implementations.